### PR TITLE
Several small improvements

### DIFF
--- a/hascss.html
+++ b/hascss.html
@@ -2,9 +2,9 @@
 
 <head>
   <title>This page is stylish</title>
-  <meta http-equiv=Content-Type content="text/html; charset=utf-8">
-  <link rel=stylesheet href="http://fonts.googleapis.com/css?family=Averia+Serif+Libre:300,400">
-  <link rel=stylesheet href=style.css>
+  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Averia+Serif+Libre:300,400">
+  <link rel="stylesheet" href="style.css">
+  <meta charset="utf-8">
   <style>
     em {
       font-style: normal;
@@ -41,7 +41,7 @@
   div is short for 'division'.
    -->
 
-  <p class=intro>
+  <p class="intro">
     This page has <strong>four</strong> style sheets: default styles
     in the <em>user agent style sheet</em>, two <em>external style
     sheets</em> and an <em>embedded style sheet</em>.

--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 
 <head>
   <title>Curriculum — JS for absolute beginners</title>
-  <link rel=stylesheet href="http://fonts.googleapis.com/css?family=Averia+Serif+Libre:300,400">
-  <link rel=stylesheet href=style.css>
-  <meta http-equiv=Content-Type content="text/html; charset=utf-8">
+  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Averia+Serif+Libre:300,400">
+  <link rel="stylesheet" href="style.css">
+  <meta charset="utf-8">
 </head>
 
 <h1>Curriculum: second day</h1>
@@ -20,7 +20,7 @@ content is HTML, and the appearance is described in CSS.</p>
 
 <aside><p>Nerdy details: HTML stands for HyperText Markup Language and
 CSS stands for Cascading Style Sheets, but no one ever says that, and
-the long names don't really matter. Dirty trick: make one of the
+the long names don’t really matter. Dirty trick: make one of the
 coaches try and explain what those names mean.</p></aside>
 
 <h2>Tools</h2>
@@ -36,7 +36,7 @@ Today, we will be writing a program using a text editor.</p>
 programmers prefer to use a code editor. Code editors have extra
 features, and make coding a lot more fun.</p>
 
-<p>We will be using Sublime Text 2. If you don't already have it
+<p>We will be using Sublime Text 2. If you don’t already have it
 installed, get it here:</p>
 
 <ul>
@@ -60,6 +60,6 @@ whenever you forget.</p>
 point you feel confused or stuck, get our attention, and we will do
 our very best to un-confuse you.</p>
 
-<h2>Let's go</h2>
+<h2>Let’s go</h2>
 
 <p><a href="page1.html">→ To the first page</a>.</p>

--- a/page1.html
+++ b/page1.html
@@ -2,14 +2,14 @@
 
 <head>
   <title>Curriculum — page 1</title>
-  <link rel=stylesheet href="http://fonts.googleapis.com/css?family=Averia+Serif+Libre:300,400">
-  <link rel=stylesheet href=style.css>
-  <meta http-equiv=Content-Type content="text/html; charset=utf-8">
+  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Averia+Serif+Libre:300,400">
+  <link rel="stylesheet" href="style.css">
+  <meta charset="utf-8">
 </head>
 
 <h1>Curriculum: page 1, HTML &amp; CSS</h1>
 
-<p>We'll learn how web pages are structured, and how to change the
+<p>We’ll learn how web pages are structured, and how to change the
 appearance of the content.</p>
 
 
@@ -40,7 +40,7 @@ example. We put our content between pairs of tags to define what the
 content is, and to determines how the text will appear.</p>
 
 <p>There are start tags such as <code>&lt;p></code> and ends tags like
-<code>&lt;/p></code>. Some tags that don't wrap around anything else
+<code>&lt;/p></code>. Some tags that don’t wrap around anything else
 and are called <em>empty elements</em>. For example, to include an
 image we use the <code>&lt;img></code> tag plus a <code>src</code>
 attribute to indicate the address of the image file.</p>
@@ -48,15 +48,15 @@ attribute to indicate the address of the image file.</p>
 <img src=http://amish-geeks.de/Khark/lolcat.jpg>
 
 <p>This page also has a <code>&lt;head></code> section where meta data
-about the entire page is defined. You'll see that's how the browser
-knows what the title of the page is, but you'll also see this
+about the entire page is defined. You’ll see that’s how the browser
+knows what the title of the page is, but you’ll also see this
 line:</p>
 
-<pre>&lt;link rel=stylesheet href=style.css></pre>
+<pre>&lt;link rel="stylesheet" href="style.css"></pre>
 
-<p>This line says that an external 'style sheet' should be applied. A
+<p>This line says that an external ‘style sheet’ should be applied. A
 style sheet is the place we can define the appearance of our HTML.
-Let's pretend we didn't see that for a moment.</p>
+Let’s pretend we didn’t see that for a moment.</p>
 
 
 <h2 class="step">View HTML that has no style sheet.</h2>
@@ -82,7 +82,7 @@ above and below <code>&lt;p></code> tags.</p>
 
 <p>These tags have <em>meaning</em> and so the browser displays the
 content in a style that makes sense to most humans that read it.
-That's kind, but wouldn't it be great to to be able to choose what
+That’s kind, but wouldn’t it be great to to be able to choose what
 font, what color, what position, and well, LOTS of things about the
 appearance? We can do that! We can do that in a style sheet.</p>
 
@@ -100,8 +100,8 @@ that has style sheets.</p>
 
 <p>View the source of the example page. Read it.</p>
 
-<p>Open the <a href="style.css">external style sheet</a> of the
-example page. Read it.</p>
+<p>Open the <a href="style.css" target="_blank">external style sheet</a>
+of the example page. Read it.</p>
 
 <h3 class=ex>Explanation</h3>
 
@@ -140,7 +140,7 @@ em {
 }
 </pre>
 
-<p>The first rule says that everything in an <code>&lt;em></code> tags
+<p>The first rule says that everything in <code>&lt;em></code> tags
 should be normal (instead of italic, which is usual), and have an
 orange background, like <em style="font-style: normal;
 background-color: orange;">this</em>. But the second rule says nothing
@@ -154,7 +154,7 @@ style="font-style: normal; background-color: pink;">this</em>.
 <h2>More JavaScript please!</h2>
 
 <p>There is a lot to learn about both HTML and CSS, but hopefully
-that's enough of an introduction will help us so we add our magic
+that’s enough of an introduction will help us so we add our magic
 power: JavaScript!</p>
 
 

--- a/page2.html
+++ b/page2.html
@@ -2,9 +2,9 @@
 
 <head>
   <title>Curriculum — page 2</title>
-  <link rel=stylesheet href="http://fonts.googleapis.com/css?family=Averia+Serif+Libre:300,400">
-  <link rel=stylesheet href=style.css>
-  <meta http-equiv=Content-Type content="text/html; charset=utf-8">
+  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Averia+Serif+Libre:300,400">
+  <link rel="stylesheet" href="style.css">
+  <meta charset="utf-8">
 </head>
 
 <h1>Curriculum: page 2, preparing your slide show</h1>
@@ -12,7 +12,7 @@
 <p>We will learn how to build your HTML slide show, and then learn
 how to use JavaScript can make content dynamic and interactive.</p>
 
-<p>For this project, we will create a photo slide show. You'll have
+<p>For this project, we will create a photo slide show. You’ll have
 more fun if your slide show is made from your own photos, or at least
 photos you like. So step one is:</p>
 
@@ -32,12 +32,12 @@ photos you like. So step one is:</p>
 <br>The photos must:</p>
 
 <ul>
-  <li>Have file type of .jpg, .gif or .png</li>
-  <li>Have a width of around 500 pixels.</li>
-  <li>All have the same dimensions in pixels.</li>
-  <li>All have the same orientation (all landscape, portrait, or
+  <li>have file type of .jpg, .gif or .png</li>
+  <li>have a width of around 500 pixels</li>
+  <li>all have the same dimensions in pixels</li>
+  <li>all have the same orientation (all landscape, portrait, or
     square)</li>
-  <li>Be photos you like. You will look at them all day!</li>
+  <li>be photos you like. You will look at them all day!</li>
 </ul>
 
 <p>Note: you can download any three photos, and edit them to be all
@@ -57,7 +57,7 @@ simpler, we want them to be not too big, and not odd sizes.</p>
 
 <h3 class=inst>Instructions</h3>
 
-<p>In a editor, open a new file.</p>
+<p>In your editor, open a new file.</p>
 
 <p>Save the file with the name “index.html” in your
 <span class="filename">slideshow</span> directory</p>
@@ -96,7 +96,7 @@ character set to UTF-8:</p>
 &lt;!doctype html>
 &lt;head>
   &lt;title>I ♥ Coding&lt;/title>
-  <strong>&lt;meta charset='utf-8'></strong>
+  <strong>&lt;meta charset="utf-8"></strong>
 &lt;/head>
 </pre>
 
@@ -105,9 +105,9 @@ the tab.</p>
 
 <h3 class=ex>Explanation</h3>
 
-<p>You've written some HTML and are looking at it in your browser!</p>
+<p>You’ve written some HTML and are looking at it in your browser!</p>
 
-<p>You've also added a title, and defined the character set so that
+<p>You’ve also added a title, and defined the character set so that
 UTF-8 characters are correctly displayed. (UTF-8 is important not just
 for hearts, but also for umlauts.)</p>
 
@@ -157,21 +157,21 @@ in pixels of your photos. There are three values you must change.</p>
 <p>Update your <span class="filename">index.html</span> file by adding a link to the
 <span class="filename">style.css</span> stylesheet in the head, and by wrapping your
 <code>&lt;img></code> tags in two <code>&lt;div></code> containers
-with classes "picture-frame" and "film-roll":</p>
+with classes “picture-frame” and “film-roll”:</p>
 
 <pre>
 &lt;!doctype html>
 &lt;head>
   &lt;title>I ♥ Coding&lt;/title>
-  &lt;meta charset='utf-8'>
-  <strong>&lt;link rel="stylesheet" href="style.css" /></strong>
+  &lt;meta charset="utf-8">
+  <strong>&lt;link rel="stylesheet" href="style.css"></strong>
 &lt;/head>
 
 <strong>&lt;div class="picture-frame"></strong>
 <strong>  &lt;div class="film-roll"></strong>
-    &lt;img src="…" />
-    &lt;img src="…" />
-    &lt;img src="…" />
+    &lt;img src="…">
+    &lt;img src="…">
+    &lt;img src="…">
 <strong>  &lt;/div></strong>
 <strong>&lt;/div></strong>
 </pre>
@@ -206,7 +206,7 @@ arrows while changing the value of the left attribute.</p>
 <p>Refresh the page to reset all the styles.</p>
 
 <p>Play with more CSS values in other rules on other elements. Turn
-styles them on and off using the checkboxes. What does each attribute
+styles on and off using the checkboxes. What does each attribute
 do?</p>
 
 <h3 class=ex>Explanation</h3>
@@ -220,7 +220,9 @@ like <code>.class-name { … }</code>, target elements with
 in completely different ways, and we can use this control to now we
 can see that CSS can also control position.</p>
 
-<p>Using this technique. we have created a “picture frame” that is
+<ins>TODO something seems to be missing here</ins>
+
+<p>Using this technique, we have created a “picture frame” that is
 centered in the page, and has a height and width that exactly matches
 our photo size. (<code>overflow: hidden</code> is needed because
 otherwise, the contents that go outside of the frame would still be
@@ -228,13 +230,13 @@ visible.)</p>
 
 <!-- an illustration would help -->
 
-<p>Inside of the picture frame, we created “film roll” that is a long
+<p>Inside of the picture frame, we created a “film roll” that is a long
 strip of all our photos. By changing the position of the film roll, we
 can make our photos slide back and forth inside the picture frame.</p>
 
 <p>We can adjust the CSS in the stylesheet, and we can adjust the CSS
 by hand in the Developer Tools, but (so exciting!) we also adjust the
-CSS using JavaScript. Ready to try?? Let's do it!</p>
+CSS using JavaScript. Ready to try?? Let’s do it!</p>
 
 <!-- an illustration would help -->
 
@@ -243,12 +245,12 @@ CSS using JavaScript. Ready to try?? Let's do it!</p>
 <h3 class=goal>Goal</h3>
 
 <p>To see that you can create a reference an HTML element, and explore
-the element's properties in the console.</p>
+the element’s properties in the console.</p>
 
 <h3 class=inst>Instructions</h3>
 
-<p>In your <span class="filename">index.html</span>, add the id "the-film-roll" to
-<code>&lt;div></code> with class film-roll:</p>
+<p>In your <span class="filename">index.html</span>, add the id “the-film-roll”
+to <code>&lt;div></code> with class film-roll:</p>
 
 <pre>
 &lt;div class="film-roll" <strong>id="the-film-roll"</strong>>
@@ -260,7 +262,7 @@ the element's properties in the console.</p>
 var filmroll = document.getElementById('the-film-roll');
 </pre>
 
-<p>The type, one line at a time. Some lines may have an unexpected
+<p>Then type, one line at a time. Some lines may have an unexpected
 effect (or unexpectedly no effect).</p>
 
 <pre>
@@ -297,16 +299,16 @@ element with an ID of our choosing.</p>
 <p>Here, we added an ID to the film roll element, and then used that
 ID to create a reference that we could control with JavaScript.</p>
 
-<p>Once we have a reference to the div with id "the-film-roll", we can
-access its properties too! Some of them (like <code>offsetLeft</code>)
-are <em>read only</em>, meaning we can't change the value. Some
+<p>Once we have a reference to the <code>div</code> with id “the-film-roll”,
+we can access its properties too! Some of them (like <code>offsetLeft</code>)
+are <em>read only</em>, meaning we can’t change the value. Some
 (maybe you found some) can be changed. Other properties, like
 <code>style</code> have properties themselves.</p>
 
 <p>The <code>style</code> property allows us to control the CSS
-attributes on an element. Therefore, but creating references to an
+properties on an element. Therefore, by creating references to an
 element (and HTML element) we can change its appearance and position
-(by setting its CSS attributes).</p>
+(by setting its CSS properties).</p>
 
 <p>The moment we refresh the page, we get a whole new environment and
 all of the variables we created are gone. How can we create variables
@@ -315,7 +317,7 @@ without typing them in the console? There must be a way!</p>
 <h2>Putting it all together</h2>
 
 <p>HTML in one page, CSS in the stylesheet, but how can we load our
-JavaScript programs? Let's find out!</p>
+JavaScript programs? Let’s find out!</p>
 
 
 <p><a href="page3.html">→ To the third page</a>.</p>

--- a/page3.html
+++ b/page3.html
@@ -2,15 +2,15 @@
 
 <head>
   <title>Curriculum — page 3</title>
-  <link rel=stylesheet href="http://fonts.googleapis.com/css?family=Averia+Serif+Libre:300,400">
-  <link rel=stylesheet href=style.css>
-  <meta http-equiv=Content-Type content="text/html; charset=utf-8">
+  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Averia+Serif+Libre:300,400">
+  <link rel="stylesheet" href="style.css">
+  <meta charset="utf-8">
 </head>
 
 <h1>Curriculum: page 3, moving pictures</h1>
 
-<p>You've written your HTML and CSS. We got a taste of how to use
-JavaScript to move around the content. Now, we'll learn how to
+<p>You’ve written your HTML and CSS. We got a taste of how to use
+JavaScript to move around the content. Now, we’ll learn how to
 include your program when the HTML is loaded, so we can make the
 content dynamic and interactive. </p>
 
@@ -33,7 +33,7 @@ reference to film roll:</p>
 var filmroll = document.getElementById('the-film-roll');
 </pre>
 
-<p>In your <code>index.js</code>, include this new file at the very
+<p>In your <code>index.html</code>, include this new file at the very
 <strong>end</strong>:</p>
 
 <pre>
@@ -85,8 +85,8 @@ function move() {
 var loop = setInterval(move, 40);
 </pre>
 
-<p>Why can't we use a <code>for</code> or <code>while</code> for this
-effect?</p>
+<p>Why can’t we use a <code>for</code> or <code>while</code> loop
+for this effect?</p>
 
 <p>Try to speed up the scrolling effect. There are two ways. Which one
 works better?</p>
@@ -129,7 +129,7 @@ loops.</p>
 <p>In the end, your function might look something like this:</p>
 
 <pre>
-var move = function () {
+function move() {
   filmroll.style.left = current + 'px';
 
   if (current == end)
@@ -178,7 +178,7 @@ var filmroll = document.getElementById('the-film-roll');
 function scroll(start, end) {
   var current = start;
 
-  var move = function () {
+  function move() {
     filmroll.style.left = current + 'px';
 
     if (current == end)
@@ -225,8 +225,8 @@ from any starting position to and ending position. Yay!</p>
 
 <h3 class=inst>Instructions</h3>
 
-<p>In <span class="filename">slideshow.js</span>, add an <em>EventLister</em> called
-<code>handleEvent</code> to the <code>document</code> that triggers on
+<p>In <span class="filename">slideshow.js</span>, add an <em>EventListener</em>
+called <code>handleEvent</code> to the <code>document</code> that triggers on
 a <code>keydown</code> event, like this:</p>
 
 <pre>
@@ -271,7 +271,7 @@ function backAndForth(keyCode) {
 <p>Try out this new functionality in Chrome. Remember to always
 refresh the page when you change your JavaScript code.</p>
 
-<p>Why doesn't it keep scrolling in the same direction when the press
+<p>Why doesn’t it keep scrolling in the same direction when you press
 the same arrow?</p>
 
 <p>Store the current scrolling position in a variable, and after
@@ -279,7 +279,7 @@ calling the <code>scroll</code> function, update the value of the
 current position. Always use the current position as the <code>start</code>
 value when you call the <code>scroll</code> function.</p>
 
-<p>Try it first! but if you need help, take a peek below:</p>
+<p>Try it first! But if you need help, take a peek below:</p>
 
 <pre>
 var current = 0;
@@ -287,23 +287,24 @@ var current = 0;
 function backAndForth(keyCode) {
   if (keyCode == 37) {
     scroll(current, current - 500);
-    current = current - 500;
+    current -= 500;
   }
 
   if (keyCode == 39) {
     scroll(current, current + 500);
-    current = current + 500;
+    current += 500;
   }
 }
 </pre>
 
 <p>The operator <code>+=</code> first adds the value on its right to
 the value of the variable on its left, updates the variable to the
-sum, and returns the sum. (It's just shorthand for
-<code>a = a + b</code>.) The <code>-=</code> operator works the same
-for subtraction. Use these operators to reduce the lines in your
-<code>handleEvent</code>function. Does this notation makes sense to
-you? Do you like it? Why or why not?</p>
+sum. (It's just shorthand for <code>a = a + b</code>.)</p>
+
+<p>The <code>-=</code> operator works the same for subtraction.
+Use these operators to reduce the lines in your <code>handleEvent</code>
+function. Does this notation makes sense to you? Do you like it?
+Why or why not?</p>
 
 <h3 class=ex>Explanation</h3>
 
@@ -313,8 +314,7 @@ whether you type something, or move your mouse. These events have
 names like “keydown”, “keyup”, and “click”, and are emitted by all
 kinds of elements in the <code>document</code>, and by the
 <code>document</code> itself. In this example, we are only listening
-to <code>keydown</code> events emitted by the
-<code>document</code>.</p>
+to <code>keydown</code> events emitted by the <code>document</code>.</p>
 
 <p>By listening to the events emitted, we can know when the person
 viewing the page has <em>interacted</em> with the page. We can look at
@@ -342,7 +342,7 @@ desirable.</p>
 them. Maybe you already noticed it. To recreate the bug, try pressing
 the left and right arrows faster than the film roll can slide. (So,
 start the film roll sliding, and then press either left or right again
-before it is finished sliding). You'll see an ugly flickering effect.
+before it is finished sliding). You’ll see an ugly flickering effect.
 
 <p>Do you know what is causing it? What can we do to stop it?</p>
 
@@ -351,9 +351,9 @@ before it is finished sliding). You'll see an ugly flickering effect.
 <h3 class=ex>Explanation</h3>
 
 <p>Lots of times when we write code, we forget that our users might do
-things that don't “make sense” at first, or will try to do things we
-didn't think of. Oops. We think our job is done, but then we find out
-our code has a bug and we have to correct it (or tell the users “Don't
+things that don’t “make sense” at first, or will try to do things we
+didn’t think of. Oops. We think our job is done, but then we find out
+our code has a bug and we have to correct it (or tell the users “Don’t
 do that!” which is sort of rude).</p>
 
 <p>First we have to figure out that the bug exists. Then we have to
@@ -404,7 +404,7 @@ expects?</p>
 
 <h2>Next!</h2>
 
-<p>Now that we've changed CSS, let's change the HTML too!</p>
+<p>Now that we’ve changed CSS, let’s change the HTML too!</p>
 
 
 <p><a href="page4.html">→ To the fourth page</a>.</p>

--- a/page4.html
+++ b/page4.html
@@ -2,19 +2,19 @@
 
 <head>
   <title>Curriculum — page 4</title>
-  <link rel=stylesheet href="http://fonts.googleapis.com/css?family=Averia+Serif+Libre:300,400">
-  <link rel=stylesheet href=style.css>
-  <meta http-equiv=Content-Type content="text/html; charset=utf-8">
+  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Averia+Serif+Libre:300,400">
+  <link rel="stylesheet" href="style.css">
+  <meta charset="utf-8">
 </head>
 
 <h1>Curriculum: page 4, more dynamic, please!</h1>
 
-<p>We've seen how we can use JavaScript to move content around on the
+<p>We’ve seen how we can use JavaScript to move content around on the
 page by changing the CSS. We can even react to the user by listening
 to events.</p>
 
 <p>But what if you want to change the order of your photos in the
-slide show? You could do it be editing the <code>&lt;img></code> tags
+slide show? You could do it by editing the <code>&lt;img></code> tags
 in the HTML, which is not a bad idea.</p>
 
 <p>We could also be very clever, and use JavaScript to rearrange
@@ -39,7 +39,7 @@ properties and methods.</p>
 <p>Visit your slide show in Chrome, and open the console.</p>
 
 <p>Remember, since we have our <span class="filename">slideshow.js</span> running, we
-have a reference to the "file role" in the variable called
+have a reference to the “film roll” in the variable called
 <code>filmroll</code>. In the console, type:</p>
 
 <pre>
@@ -54,7 +54,7 @@ value:</p>
 filmroll.innerHTML = "Remember, strings need quotes."
 </pre>
 
-<p>You can also use numbers, and do math, it you wanted:</p>
+<p>You can also use numbers, and do math, if you wanted:</p>
 
 <pre>
 filmroll.innerHTML = 4 + 3 * 111 + 1000
@@ -77,7 +77,7 @@ filmroll.innerHTML += "&lt;p>Yeah! Lots of potential.&lt;/p>"
 
 <pre>
 var address = "http://tif.ca/hello.jpg";
-var html = "&lt;img src=" + address + ">"
+var html = "&lt;img src=" + address + ">";
 filmroll.innerHTML = html;
 </pre>
 
@@ -93,7 +93,7 @@ browser as HTML.<p>
 write to it, which means we can add the new HTML to the existing
 <code>innerHTML</code> to add, rather than replace, content.</p>
 
-<p>Because we can "add" strings of text together, we can also create
+<p>Because we can “add” strings of text together, we can also create
   HTML, and then use it to set <code>innerHTML</code>.</p>
 
 <p>This technique is not the only way to add content to the document,
@@ -129,16 +129,16 @@ var html = "";
 </pre>
 
 <p>In your <span class="filename">index.html</span>, delete all the image tags that are
-inside of your "film roll" <code>&lt;div></code> (the one with
-id="the-film-roll"). Your <span class="filename">index.html</span> will looks like this
-afterwards:</p>
+inside of your “film roll” <code>&lt;div></code> (the one with
+<code>id="the-film-roll"</code>). Your <span class="filename">index.html</span>
+will looks like this afterwards:</p>
 
 <pre>
 &lt;!doctype html>
 &lt;head>
   &lt;title>I ♥ Coding&lt;/title>
-  &lt;meta charset='utf-8'>
-  &lt;link rel="stylesheet" href="style.css" />
+  &lt;meta charset="utf-8">
+  &lt;link rel="stylesheet" href="style.css">
 &lt;/head>
 
 &lt;div class="picture-frame">
@@ -164,7 +164,7 @@ for (var i = 0; i &lt; photos.length; i++) {
 </pre>
 
 <p>Recall that the value stored a index <code>i</code> of the array
-<code>photos</code> is accessed like this
+<code>photos</code> is accessed like this:
 <code>photos[i]</code></p>
 
 <p>Update the loop so that each time, the value stored in
@@ -200,4 +200,4 @@ to the page.</p>
 the order of the photos by changing the order of the array.
 
 <p>It would also be easy to just edit the HTML, but this is so much
-more clever, right?)<p>
+more clever, right?<p>


### PR DESCRIPTION
- Several typos
- Use HTML syntax consistently instead of XHTML for self-closing tags
- Use typographic quotes consistently
- Use meta charset="utf-8" also in the curriculum HTML
- Use "" as attribute delimiters in HTML consistently (and don’t omit them)
- Use the term “CSS property” instead of “attribute”, hope that’s okay

I hope it’s not too much nitpicking and style changes ;)

On page 2 we’ve found a probable gap in the text (with regard to contents), I’ve added an `ins` to mark it.
